### PR TITLE
17 warning if non csv file is attepted to be loaded into rslt importphp

### DIFF
--- a/admin2/results2/rslt_process.php
+++ b/admin2/results2/rslt_process.php
@@ -343,7 +343,7 @@ function IsValidFileType($filename,$type)
 
 function abort_and_return_to_index()
 {
-	header("location:index.php");
+	header("location:rslt_import.php");
 	exit();
 }
 

--- a/admin2/results2/rslt_process.php
+++ b/admin2/results2/rslt_process.php
@@ -3,7 +3,7 @@ session_start();
 $_SESSION['err_code'] = 0;
 
 if (!isset($_POST['sked_id']))
-	header("location:index.php");
+	abort_and_return_to_index();
 else
 	$sked_id = intval($_POST['sked_id']);
 
@@ -19,10 +19,9 @@ else
 if ($_SESSION['err_code']) {
 	$_SESSION['sked_id'] = $sked_id;
 	$_SESSION['csvfilename'] = $_FILES['csvfile']['name'];
-	header("location:index.php");
+	abort_and_return_to_index();
 }
 
-header("location:index.php");
 
 //if we made it this far, then consider the input data valid...
 
@@ -340,6 +339,12 @@ function IsValidFileType($filename,$type)
 			break;
 	}
 	return $err_code;
+}
+
+function abort_and_return_to_index()
+{
+	header("location:index.php");
+	exit();
 }
 
 function quote_all_array($values) { 

--- a/admin2/results2/rslt_process.php
+++ b/admin2/results2/rslt_process.php
@@ -3,7 +3,7 @@ session_start();
 $_SESSION['err_code'] = 0;
 
 if (!isset($_POST['sked_id']))
-	abort_and_return_to_index();
+	abort_and_return_to_index($sked_id);
 else
 	$sked_id = intval($_POST['sked_id']);
 
@@ -19,7 +19,7 @@ else
 if ($_SESSION['err_code']) {
 	$_SESSION['sked_id'] = $sked_id;
 	$_SESSION['csvfilename'] = $_FILES['csvfile']['name'];
-	abort_and_return_to_index();
+	abort_and_return_to_index($sked_id);
 }
 
 
@@ -341,7 +341,7 @@ function IsValidFileType($filename,$type)
 	return $err_code;
 }
 
-function abort_and_return_to_index()
+function abort_and_return_to_index($sked_id)
 {
 	header("location:rslt_import.php?sked_id=" . $sked_id);
 	exit();

--- a/admin2/results2/rslt_process.php
+++ b/admin2/results2/rslt_process.php
@@ -343,7 +343,7 @@ function IsValidFileType($filename,$type)
 
 function abort_and_return_to_index()
 {
-	header("location:rslt_import.php");
+	header("location:rslt_import.php?sked_id=" . $sked_id);
 	exit();
 }
 

--- a/admin2/results2/rslt_process.php
+++ b/admin2/results2/rslt_process.php
@@ -22,6 +22,8 @@ if ($_SESSION['err_code']) {
 	header("location:index.php");
 }
 
+header("location:index.php");
+
 //if we made it this far, then consider the input data valid...
 
 include_once("../../tools/dvoa_tools.inc.php");


### PR DESCRIPTION
Updated source code to fix Issue 17 along with other bugs found along the way.

Now, when the user uploads a non-CSV file, it is rejected using the new abort function, and an appropriate error message is shown. The event name is saved by maintaining the schedule ID so the user does not have to manually select it again.